### PR TITLE
feat: add topic resources in feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
           "In these cases the family can afford the costs",
         ],
         explanation: "'Cases' is plural, so use 'these', not 'this'.",
+        topicNote: "Demonstratives: 'these' matches plural nouns like 'cases'.",
+        referenceUrl: "https://www.grammarly.com/blog/this-these/",
       },
       {
         id: "A2",
@@ -85,6 +87,8 @@
           "The government should pay for the care.",
         ],
         explanation: "'Care' is uncountable in this context; no plural 'cares'.",
+        topicNote: "Uncountable nouns do not take plural forms like 'cares'.",
+        referenceUrl: "https://www.grammarly.com/blog/uncountable-nouns/",
       },
       {
         id: "A3",
@@ -96,6 +100,8 @@
         ],
         explanation:
           "Use singular 'a … job' or plural '… jobs' (without 'a').",
+        topicNote: "Articles: use 'a job' for singular or drop 'a' for plural 'jobs'.",
+        referenceUrl: "https://www.grammarly.com/blog/articles/",
       },
       {
         id: "A4",
@@ -107,6 +113,8 @@
         ],
         explanation:
           "Don't add an apostrophe after 'people' when it's a noun phrase ('old people'). The possessive variant changes the structure: 'old people's rights'.",
+        topicNote: "No apostrophe after plural nouns like 'people' in a noun phrase.",
+        referenceUrl: "https://www.grammarly.com/blog/apostrophe/",
       },
       {
         id: "A5",
@@ -118,6 +126,8 @@
           "In Britain, the NHS provides support for elderly people.",
         ],
         explanation: "Preferred collocation: 'the elderly' or 'elderly people'.",
+        topicNote: "Use 'the elderly' or 'elderly people'—not 'elder people'.",
+        referenceUrl: "https://www.englishclub.com/vocabulary/adjectives/elder-elderly/",
       },
       // Subject–Verb Agreement
       {
@@ -126,6 +136,8 @@
         prompt: "Fix the sentence: The system can takes care of them.",
         accepted: ["The system can take care of them."],
         explanation: "Modal 'can' is followed by the base verb 'take'.",
+        topicNote: "After modal verbs like 'can', use the base form of the verb.",
+        referenceUrl: "https://www.grammarly.com/blog/modal-verbs/",
       },
       {
         id: "S2",
@@ -136,6 +148,8 @@
           "The families were able to pay for the services.",
         ],
         explanation: "Plural subject 'families' → 'were'.",
+        topicNote: "Plural subjects take plural verbs like 'were'.",
+        referenceUrl: "https://www.grammarly.com/blog/subject-verb-agreement/",
       },
       {
         id: "S3",
@@ -143,6 +157,8 @@
         prompt: "Fix the sentence: This families are rich.",
         accepted: ["These families are rich."],
         explanation: "Plural demonstrative with plural noun: 'these families'.",
+        topicNote: "Use 'these' with plural nouns such as 'families'.",
+        referenceUrl: "https://www.grammarly.com/blog/this-these/",
       },
       {
         id: "S4",
@@ -154,6 +170,8 @@
         ],
         explanation:
           "Uncountable 'money' is grammatically singular → 'makes'. The second clause may refer to 'the elderly' (people).",
+        topicNote: "'Money' is treated as singular, so use 'makes'.",
+        referenceUrl: "https://www.grammarly.com/blog/money-is/",
       },
       // Prepositions & Word Forms
       {
@@ -167,6 +185,8 @@
           "Many people cannot access a good education.",
         ],
         explanation: "Use 'access' as a verb without 'to'.",
+        topicNote: "When 'access' is a verb, it isn't followed by 'to'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/access",
       },
       {
         id: "P2",
@@ -177,6 +197,8 @@
           "Governments must help those who cannot afford to pay for care.",
         ],
         explanation: "Use 'afford to' + base verb.",
+        topicNote: "Structure: 'afford to' + verb.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/afford",
       },
       {
         id: "P3",
@@ -184,6 +206,8 @@
         prompt: "Rewrite correctly: They are unable (cover / to cover) the expenses.",
         accepted: ["They are unable to cover the expenses."],
         explanation: "'Unable to' + base verb.",
+        topicNote: "'Unable' is followed by 'to' + base verb.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/unable",
       },
       {
         id: "P4",
@@ -192,6 +216,8 @@
           "Rewrite correctly: It is almost impossible for them (save / to save) money.",
         accepted: ["It is almost impossible for them to save money."],
         explanation: "'Impossible for them to' + base verb.",
+        topicNote: "Use 'to' after adjectives like 'impossible' before a verb.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/impossible",
       },
       // Spelling
       {
@@ -200,6 +226,8 @@
         prompt: "Correct the spelling: particullary",
         accepted: ["particularly"],
         explanation: "",
+        topicNote: "Spelling: 'particularly' with 'lar' and double 'l'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/particularly",
       },
       {
         id: "SP2",
@@ -207,6 +235,8 @@
         prompt: "Correct the spelling: acces",
         accepted: ["access"],
         explanation: "",
+        topicNote: "Spelling: double 'c' and double 's' in 'access'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/access",
       },
       {
         id: "SP3",
@@ -214,6 +244,8 @@
         prompt: "Correct the spelling: asistance",
         accepted: ["assistance"],
         explanation: "",
+        topicNote: "Spelling: 'assistance' has double 's' and ends with 'ance'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/assistance",
       },
       {
         id: "SP4",
@@ -221,6 +253,8 @@
         prompt: "Correct the spelling: inconvinience",
         accepted: ["inconvenience"],
         explanation: "",
+        topicNote: "Spelling: 'inconvenience' uses 'ie' and double 'n'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/inconvenience",
       },
       {
         id: "SP5",
@@ -228,6 +262,8 @@
         prompt: "Correct the spelling: literaly",
         accepted: ["literally"],
         explanation: "",
+        topicNote: "Spelling: 'literally' ends with 'ally'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/literally",
       },
       {
         id: "SP6",
@@ -235,6 +271,8 @@
         prompt: "Correct the spelling: imposible",
         accepted: ["impossible"],
         explanation: "",
+        topicNote: "Spelling: 'impossible' with double 's'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/impossible",
       },
       {
         id: "SP7",
@@ -242,6 +280,8 @@
         prompt: "Correct the spelling: Altough",
         accepted: ["Although", "although"],
         explanation: "",
+        topicNote: "Spelling: 'although' begins with 'al'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/although",
       },
       {
         id: "SP8",
@@ -249,6 +289,8 @@
         prompt: "Correct the spelling: aditional",
         accepted: ["additional"],
         explanation: "",
+        topicNote: "Spelling: 'additional' has double 'd'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/additional",
       },
       {
         id: "SP9",
@@ -256,6 +298,8 @@
         prompt: "Correct the spelling: familly",
         accepted: ["family"],
         explanation: "",
+        topicNote: "Spelling: 'family' ends with 'ly'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/family",
       },
       {
         id: "SP10",
@@ -263,6 +307,8 @@
         prompt: "Correct the spelling: governmnents",
         accepted: ["governments"],
         explanation: "",
+        topicNote: "Spelling: 'governments' drops the extra 'n'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/government",
       },
       // Lexical Upgrade
       {
@@ -272,6 +318,8 @@
         accepted: ["are unable to cover the costs"],
         mode: "containsPhrase",
         explanation: "Use 'are unable to cover the costs'.",
+        topicNote: "Replace simple verbs with the phrase 'are unable to cover the costs'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/cover",
       },
       {
         id: "L2",
@@ -280,6 +328,8 @@
         accepted: ["a financial burden"],
         mode: "containsPhrase",
         explanation: "Use 'a financial burden'.",
+        topicNote: "Upgrade 'difficult' to the phrase 'a financial burden'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/burden",
       },
       {
         id: "L3",
@@ -288,6 +338,8 @@
         accepted: ["highly debated issue"],
         mode: "containsPhrase",
         explanation: "Use 'a highly debated issue'.",
+        topicNote: "Upgrade to 'a highly debated issue' for formal tone.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/debate",
       },
       {
         id: "L4",
@@ -297,6 +349,8 @@
         accepted: ["economic hardship"],
         mode: "containsPhrase",
         explanation: "Use 'economic hardship'.",
+        topicNote: "Use the noun phrase 'economic hardship'.",
+        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/hardship",
       },
       {
         id: "L5",
@@ -305,6 +359,8 @@
         accepted: ["unfeasible"],
         mode: "containsPhrase",
         explanation: "Use 'It is unfeasible for them to save.'.",
+        topicNote: "Use 'unfeasible' instead of 'impossible'.",
+        referenceUrl: "https://www.merriam-webster.com/dictionary/unfeasible",
       },
     ];
 
@@ -553,23 +609,40 @@
                     </p>
                   )}
 
-                  <div className="mt-3">
-                    <div className="text-xs uppercase tracking-wider text-slate-500 mb-1">Model answer(s)</div>
-                    <ul className="list-disc pl-6 text-sm text-slate-800">
-                      {current?.accepted.map((a, i) => (
-                        <li key={i}>{a}</li>
-                      ))}
-                    </ul>
-                  </div>
-
-                  {status && (
-                    <div className="mt-4 text-xs text-slate-600">
-                      Tip: Compare your answer to the model. If you were "Almost", it was likely a small spelling or agreement issue. 🔍
+                    <div className="mt-3">
+                      <div className="text-xs uppercase tracking-wider text-slate-500 mb-1">Model answer(s)</div>
+                      <ul className="list-disc pl-6 text-sm text-slate-800">
+                        {current?.accepted.map((a, i) => (
+                          <li key={i}>{a}</li>
+                        ))}
+                      </ul>
                     </div>
-                  )}
-                </div>
-              )}
-            </div>
+
+                    {current?.topicNote && (
+                      <div className="mt-4 rounded-xl bg-white p-3">
+                        <div className="text-sm font-medium mb-1">📖 Learn More About This Topic</div>
+                        <p className="text-sm text-slate-700">{current.topicNote}</p>
+                        {current.referenceUrl && (
+                          <a
+                            href={current.referenceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-2 inline-block text-sm text-sky-700 underline"
+                          >
+                            Read more →
+                          </a>
+                        )}
+                      </div>
+                    )}
+
+                    {status && (
+                      <div className="mt-4 text-xs text-slate-600">
+                        Tip: Compare your answer to the model. If you were "Almost", it was likely a small spelling or agreement issue. 🔍
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
 
             {/* Footer actions */}
             <div className="mt-6 flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- add topic notes and reference links to every question in the bank
- show a new "Learn More" section in feedback with optional external link

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a23485577c832ab851433716d6b6ef