### PR TITLE
Load questions from external JSON with grammar metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 This repository contains a single-page web application built with React and Tailwind CSS for practicing English grammar and vocabulary.
 
 ### Top-level files
-- **`index.html`**: The entire application lives in this file. It includes Tailwind, React, ReactDOM, and Babel via CDN links. All JavaScript, JSX, and styling are embedded directly in the file.
+- **`index.html`**: React app shell; fetches questions from `questions.json` and renders the interface.
+- **`questions.json`**: External question bank with grammar metadata and reference links.
 - **`README.md`**: You are reading it.
 
 ## Main components and flow
@@ -12,8 +13,8 @@ This repository contains a single-page web application built with React and Tail
    - `normalize`: lowercases, removes punctuation, and standardizes quotes.
    - `levenshtein`: computes edit distance between the student's response and the model answer.
    - `shuffle`: randomizes question order.
-2. **Question bank (`BANK`)**
-   - An array of objects containing `id`, `category`, `prompt`, acceptable answers, and explanations.
+2. **External question bank (`questions.json`)**
+   - Provides `id`, `category`, `prompt`, accepted answers, explanations, grammar titles, topic notes, detailed guidance, and reference URLs.
 3. **`EnglishDrillApp` React component**
    - Uses React hooks for state management.
    - Functions like `checkAnswer`, `skip`, `next`, and `reshuffle` control question flow.
@@ -34,4 +35,13 @@ This repository contains a single-page web application built with React and Tail
 
 ## Summary
 This project is a small, standalone React application delivered entirely through a single HTML file. It demonstrates how to build an interactive language-drill tool using only CDN-supplied libraries and browser-side Babel. To grow or contribute, focus on mastering React hooks, Tailwind’s styling conventions, and basic algorithmic text processing. From there, the natural next step is learning how to modularize the code and introduce a build process for larger-scale development.
+
+## Development
+
+Run a local server to avoid browser `fetch` restrictions:
+
+- `python -m http.server 8080`
+- or `npx serve`
+
+Open `http://localhost:8080/` and edit `questions.json` to update content—no rebuild required.
 

--- a/index.html
+++ b/index.html
@@ -62,319 +62,36 @@
       return a;
     };
 
-    // --- Question bank ---------------------------------------------------------
-    const BANK = [
-      // Articles & Plurals
-      {
-        id: "A1",
-        category: "Articles & Plurals",
-        prompt: "Fix the sentence: In this cases, the family can afford the costs.",
-        accepted: [
-          "In these cases, the family can afford the costs.",
-          "In these cases the family can afford the costs",
-        ],
-        explanation: "'Cases' is plural, so use 'these', not 'this'.",
-        topicNote: "Demonstratives: 'these' matches plural nouns like 'cases'.",
-        referenceUrl: "https://www.grammarly.com/blog/this-these/",
-      },
-      {
-        id: "A2",
-        category: "Articles & Plurals",
-        prompt: "Fix the sentence: The government should pay for that cares.",
-        accepted: [
-          "The government should pay for that care.",
-          "The government should pay for care.",
-          "The government should pay for the care.",
-        ],
-        explanation: "'Care' is uncountable in this context; no plural 'cares'.",
-        topicNote: "Uncountable nouns do not take plural forms like 'cares'.",
-        referenceUrl: "https://www.grammarly.com/blog/uncountable-nouns/",
-      },
-      {
-        id: "A3",
-        category: "Articles & Plurals",
-        prompt: "Fix the sentence: He had access to a well-paid jobs.",
-        accepted: [
-          "He had access to a well-paid job.",
-          "He had access to well-paid jobs.",
-        ],
-        explanation:
-          "Use singular 'a … job' or plural '… jobs' (without 'a').",
-        topicNote: "Articles: use 'a job' for singular or drop 'a' for plural 'jobs'.",
-        referenceUrl: "https://www.grammarly.com/blog/articles/",
-      },
-      {
-        id: "A4",
-        category: "Articles & Plurals",
-        prompt: "Fix the sentence: We must respect the rights of old people’s.",
-        accepted: [
-          "We must respect the rights of old people.",
-          "We must respect old people's rights.",
-        ],
-        explanation:
-          "Don't add an apostrophe after 'people' when it's a noun phrase ('old people'). The possessive variant changes the structure: 'old people's rights'.",
-        topicNote: "No apostrophe after plural nouns like 'people' in a noun phrase.",
-        referenceUrl: "https://www.grammarly.com/blog/apostrophe/",
-      },
-      {
-        id: "A5",
-        category: "Articles & Plurals",
-        prompt:
-          "Fix the sentence: In Britain, the NHS provides support for elder people.",
-        accepted: [
-          "In Britain, the NHS provides support for the elderly.",
-          "In Britain, the NHS provides support for elderly people.",
-        ],
-        explanation: "Preferred collocation: 'the elderly' or 'elderly people'.",
-        topicNote: "Use 'the elderly' or 'elderly people'—not 'elder people'.",
-        referenceUrl: "https://www.englishclub.com/vocabulary/adjectives/elder-elderly/",
-      },
-      // Subject–Verb Agreement
-      {
-        id: "S1",
-        category: "Subject–Verb Agreement",
-        prompt: "Fix the sentence: The system can takes care of them.",
-        accepted: ["The system can take care of them."],
-        explanation: "Modal 'can' is followed by the base verb 'take'.",
-        topicNote: "After modal verbs like 'can', use the base form of the verb.",
-        referenceUrl: "https://www.grammarly.com/blog/modal-verbs/",
-      },
-      {
-        id: "S2",
-        category: "Subject–Verb Agreement",
-        prompt: "Fix the sentence: Families was able to pay for the services.",
-        accepted: [
-          "Families were able to pay for the services.",
-          "The families were able to pay for the services.",
-        ],
-        explanation: "Plural subject 'families' → 'were'.",
-        topicNote: "Plural subjects take plural verbs like 'were'.",
-        referenceUrl: "https://www.grammarly.com/blog/subject-verb-agreement/",
-      },
-      {
-        id: "S3",
-        category: "Subject–Verb Agreement",
-        prompt: "Fix the sentence: This families are rich.",
-        accepted: ["These families are rich."],
-        explanation: "Plural demonstrative with plural noun: 'these families'.",
-        topicNote: "Use 'these' with plural nouns such as 'families'.",
-        referenceUrl: "https://www.grammarly.com/blog/this-these/",
-      },
-      {
-        id: "S4",
-        category: "Subject–Verb Agreement",
-        prompt: "Fix the sentence: Money make life easier for elderly care.",
-        accepted: [
-          "Money makes life easier for elderly care.",
-          "Money makes life easier for the elderly.",
-        ],
-        explanation:
-          "Uncountable 'money' is grammatically singular → 'makes'. The second clause may refer to 'the elderly' (people).",
-        topicNote: "'Money' is treated as singular, so use 'makes'.",
-        referenceUrl: "https://www.grammarly.com/blog/money-is/",
-      },
-      // Prepositions & Word Forms
-      {
-        id: "P1",
-        category: "Prepositions & Word Forms",
-        prompt:
-          "Rewrite correctly: Many people cannot (access / access to) good education.",
-        accepted: [
-          "Many people cannot access good education.",
-          "Many people cannot access good-quality education.",
-          "Many people cannot access a good education.",
-        ],
-        explanation: "Use 'access' as a verb without 'to'.",
-        topicNote: "When 'access' is a verb, it isn't followed by 'to'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/access",
-      },
-      {
-        id: "P2",
-        category: "Prepositions & Word Forms",
-        prompt:
-          "Rewrite correctly: Governments must help those who cannot (afford / afford to) pay for care.",
-        accepted: [
-          "Governments must help those who cannot afford to pay for care.",
-        ],
-        explanation: "Use 'afford to' + base verb.",
-        topicNote: "Structure: 'afford to' + verb.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/afford",
-      },
-      {
-        id: "P3",
-        category: "Prepositions & Word Forms",
-        prompt: "Rewrite correctly: They are unable (cover / to cover) the expenses.",
-        accepted: ["They are unable to cover the expenses."],
-        explanation: "'Unable to' + base verb.",
-        topicNote: "'Unable' is followed by 'to' + base verb.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/unable",
-      },
-      {
-        id: "P4",
-        category: "Prepositions & Word Forms",
-        prompt:
-          "Rewrite correctly: It is almost impossible for them (save / to save) money.",
-        accepted: ["It is almost impossible for them to save money."],
-        explanation: "'Impossible for them to' + base verb.",
-        topicNote: "Use 'to' after adjectives like 'impossible' before a verb.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/impossible",
-      },
-      // Spelling
-      {
-        id: "SP1",
-        category: "Spelling",
-        prompt: "Correct the spelling: particullary",
-        accepted: ["particularly"],
-        explanation: "",
-        topicNote: "Spelling: 'particularly' with 'lar' and double 'l'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/particularly",
-      },
-      {
-        id: "SP2",
-        category: "Spelling",
-        prompt: "Correct the spelling: acces",
-        accepted: ["access"],
-        explanation: "",
-        topicNote: "Spelling: double 'c' and double 's' in 'access'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/access",
-      },
-      {
-        id: "SP3",
-        category: "Spelling",
-        prompt: "Correct the spelling: asistance",
-        accepted: ["assistance"],
-        explanation: "",
-        topicNote: "Spelling: 'assistance' has double 's' and ends with 'ance'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/assistance",
-      },
-      {
-        id: "SP4",
-        category: "Spelling",
-        prompt: "Correct the spelling: inconvinience",
-        accepted: ["inconvenience"],
-        explanation: "",
-        topicNote: "Spelling: 'inconvenience' uses 'ie' and double 'n'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/inconvenience",
-      },
-      {
-        id: "SP5",
-        category: "Spelling",
-        prompt: "Correct the spelling: literaly",
-        accepted: ["literally"],
-        explanation: "",
-        topicNote: "Spelling: 'literally' ends with 'ally'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/literally",
-      },
-      {
-        id: "SP6",
-        category: "Spelling",
-        prompt: "Correct the spelling: imposible",
-        accepted: ["impossible"],
-        explanation: "",
-        topicNote: "Spelling: 'impossible' with double 's'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/impossible",
-      },
-      {
-        id: "SP7",
-        category: "Spelling",
-        prompt: "Correct the spelling: Altough",
-        accepted: ["Although", "although"],
-        explanation: "",
-        topicNote: "Spelling: 'although' begins with 'al'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/although",
-      },
-      {
-        id: "SP8",
-        category: "Spelling",
-        prompt: "Correct the spelling: aditional",
-        accepted: ["additional"],
-        explanation: "",
-        topicNote: "Spelling: 'additional' has double 'd'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/additional",
-      },
-      {
-        id: "SP9",
-        category: "Spelling",
-        prompt: "Correct the spelling: familly",
-        accepted: ["family"],
-        explanation: "",
-        topicNote: "Spelling: 'family' ends with 'ly'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/family",
-      },
-      {
-        id: "SP10",
-        category: "Spelling",
-        prompt: "Correct the spelling: governmnents",
-        accepted: ["governments"],
-        explanation: "",
-        topicNote: "Spelling: 'governments' drops the extra 'n'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/government",
-      },
-      // Lexical Upgrade
-      {
-        id: "L1",
-        category: "Lexical Upgrade",
-        prompt: "Rewrite with a more academic alternative: Many families cannot afford this.",
-        accepted: ["are unable to cover the costs"],
-        mode: "containsPhrase",
-        explanation: "Use 'are unable to cover the costs'.",
-        topicNote: "Replace simple verbs with the phrase 'are unable to cover the costs'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/cover",
-      },
-      {
-        id: "L2",
-        category: "Lexical Upgrade",
-        prompt: "Rewrite with a more academic alternative: Paying for care is difficult.",
-        accepted: ["a financial burden"],
-        mode: "containsPhrase",
-        explanation: "Use 'a financial burden'.",
-        topicNote: "Upgrade 'difficult' to the phrase 'a financial burden'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/burden",
-      },
-      {
-        id: "L3",
-        category: "Lexical Upgrade",
-        prompt: "Rewrite with a more academic alternative: This is a really controversial topic.",
-        accepted: ["highly debated issue"],
-        mode: "containsPhrase",
-        explanation: "Use 'a highly debated issue'.",
-        topicNote: "Upgrade to 'a highly debated issue' for formal tone.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/debate",
-      },
-      {
-        id: "L4",
-        category: "Lexical Upgrade",
-        prompt:
-          "Rewrite with a more academic alternative: Families are in a difficult financial situation.",
-        accepted: ["economic hardship"],
-        mode: "containsPhrase",
-        explanation: "Use 'economic hardship'.",
-        topicNote: "Use the noun phrase 'economic hardship'.",
-        referenceUrl: "https://dictionary.cambridge.org/dictionary/english/hardship",
-      },
-      {
-        id: "L5",
-        category: "Lexical Upgrade",
-        prompt: "Rewrite with a more academic alternative: It is impossible for them to save.",
-        accepted: ["unfeasible"],
-        mode: "containsPhrase",
-        explanation: "Use 'It is unfeasible for them to save.'.",
-        topicNote: "Use 'unfeasible' instead of 'impossible'.",
-        referenceUrl: "https://www.merriam-webster.com/dictionary/unfeasible",
-      },
-    ];
-
-    const CATEGORIES = [
-      "All",
-      "Articles & Plurals",
-      "Subject–Verb Agreement",
-      "Prepositions & Word Forms",
-      "Spelling",
-      "Lexical Upgrade",
-    ];
+    // --- Load questions from external JSON -------------------------------------
+    async function loadQuestions() {
+      const res = await fetch('./questions.json', { cache: 'no-store' });
+      if (!res.ok) throw new Error('Failed to fetch questions.json');
+      const data = await res.json();
+      if (!data || !Array.isArray(data.questions)) {
+        throw new Error('Invalid schema: missing questions[]');
+      }
+      const cleaned = data.questions
+        .filter(
+          (q) =>
+            q &&
+            typeof q.id === 'string' &&
+            typeof q.category === 'string' &&
+            typeof q.prompt === 'string' &&
+            Array.isArray(q.accepted) &&
+            typeof q.explanation === 'string' &&
+            typeof q.topicNote === 'string' &&
+            typeof q.grammarTitle === 'string' &&
+            typeof q.detailedExplanation === 'string'
+        )
+        .map((q) => ({ ...q, mode: q.mode || 'exact' }));
+      if (!cleaned.length) throw new Error('No valid questions found');
+      return cleaned;
+    }
 
     // --- Component --------------------------------------------------------------
-    const EnglishDrillApp = () => {
+    const EnglishDrillApp = ({ initialBank = [] }) => {
+      const BANK = initialBank;
+      const categories = useMemo(() => ['All', ...Array.from(new Set(BANK.map((q) => q.category)))], [BANK]);
       const [category, setCategory] = useState("All");
       const [order, setOrder] = useState(() => shuffle(BANK.map((q) => q.id)));
       const [index, setIndex] = useState(0);
@@ -498,7 +215,7 @@
                     setAnswer("");
                   }}
                 >
-                  {CATEGORIES.map((c) => (
+                  {categories.map((c) => (
                     <option key={c} value={c}>
                       {c}
                     </option>
@@ -618,10 +335,19 @@
                       </ul>
                     </div>
 
-                    {current?.topicNote && (
+                    {(current?.grammarTitle || current?.topicNote || current?.detailedExplanation || current?.referenceUrl) && (
                       <div className="mt-4 rounded-xl bg-white p-3">
-                        <div className="text-sm font-medium mb-1">📖 Learn More About This Topic</div>
-                        <p className="text-sm text-slate-700">{current.topicNote}</p>
+                        {current.grammarTitle && (
+                          <div className="text-sm font-medium mb-1">{current.grammarTitle}</div>
+                        )}
+                        {current.topicNote && (
+                          <p className="text-sm text-slate-700">{current.topicNote}</p>
+                        )}
+                        {current.detailedExplanation && (
+                          <p className="mt-2 whitespace-pre-line text-sm text-slate-700">
+                            {current.detailedExplanation}
+                          </p>
+                        )}
                         {current.referenceUrl && (
                           <a
                             href={current.referenceUrl}
@@ -674,8 +400,28 @@
       );
     };
 
+    function AppBootstrap() {
+      const [s, setS] = React.useState({ loading: true, error: null, bank: [] });
+
+      React.useEffect(() => {
+        loadQuestions()
+          .then((bank) => setS({ loading: false, error: null, bank }))
+          .catch((err) => setS({ loading: false, error: err.message, bank: [] }));
+      }, []);
+
+      if (s.loading) return <div className="p-6 text-sm text-slate-600">Loading questions…</div>;
+      if (s.error)
+        return (
+          <div className="m-4 p-4 rounded-xl bg-rose-50 text-rose-700 text-sm">
+            Couldn’t load questions: {s.error}
+            <button className="ml-3 underline" onClick={() => location.reload()}>Retry</button>
+          </div>
+        );
+      return <EnglishDrillApp initialBank={s.bank} />;
+    }
+
     const root = ReactDOM.createRoot(document.getElementById("root"));
-    root.render(<EnglishDrillApp />);
+    root.render(<AppBootstrap />);
   </script>
 </body>
 </html>

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,47 @@
+{
+  "questions": [
+    {
+      "id": "A1",
+      "category": "Articles & Plurals",
+      "prompt": "Fix the sentence: In this cases, the family can afford the costs.",
+      "accepted": [
+        "In these cases, the family can afford the costs.",
+        "In these cases the family can afford the costs"
+      ],
+      "explanation": "'Cases' is plural, so use 'these', not 'this'.",
+      "topicNote": "Demonstratives: 'these' matches plural nouns like 'cases'.",
+      "referenceUrl": "https://www.grammarly.com/blog/this-these/",
+      "grammarTitle": "Demonstratives with Singular and Plural Nouns",
+      "detailedExplanation": "Use 'this' for singular nouns close in time/space and 'these' for plural nouns. Since 'cases' is plural, choose 'these'. Tips: read the noun aloud first; if it ends with an -s plural, match with 'these'. Practise by rewriting 10 singular examples into plural.",
+      "mode": "exact"
+    },
+    {
+      "id": "S1",
+      "category": "Subject–Verb Agreement",
+      "prompt": "Fix the sentence: The system can takes care of them.",
+      "accepted": ["The system can take care of them."],
+      "explanation": "Modals (can, could, may, might, must, should) take the base form.",
+      "topicNote": "After a modal, drop the -s/-ed: use the bare infinitive.",
+      "referenceUrl": "https://dictionary.cambridge.org/grammar/british-grammar/modal-verbs",
+      "grammarTitle": "Modal Verbs + Base Form",
+      "detailedExplanation": "Modal verbs are followed by the base form: can take, should consider, must pay. Do not add third-person -s or 'to'. Tip: mentally say 'to' before the verb; if it sounds wrong ('can to take'), you likely need the base form.",
+      "mode": "exact"
+    },
+    {
+      "id": "P1",
+      "category": "Prepositions & Word Forms",
+      "prompt": "Rewrite correctly: Many people cannot (access / access to) good education.",
+      "accepted": [
+        "Many people cannot access good education.",
+        "Many people cannot access good-quality education.",
+        "Many people cannot access a good education."
+      ],
+      "explanation": "Use 'access' as a verb without 'to'.",
+      "topicNote": "Verb 'access' takes a direct object: access something.",
+      "referenceUrl": "https://www.merriam-webster.com/dictionary/access",
+      "grammarTitle": "Transitive Verbs without Prepositions",
+      "detailedExplanation": "Some verbs are directly transitive (need no preposition): access information, discuss a problem, approach a topic. Adding 'to' is a common L2 interference. Tip: build a personal list of no-preposition verbs and drill with object nouns.",
+      "mode": "exact"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fetch drill questions from an external `questions.json` file with grammar metadata and reference URLs
- Display grammar title, topic note, detailed explanation and optional resource link in the feedback panel
- Add bootstrap loader with loading/error states and document local server usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a415140832a9e40093a960d92d4